### PR TITLE
Feat: Seller, Member JWT 필터 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### Project ###
-src/main/resources/application*.yml
+#src/main/resources/application*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    // implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.cloud:spring-cloud-starter'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/src/main/java/shop/kokodo/apigatewayservice/filter/MemberAuthenticationFilter.java
+++ b/src/main/java/shop/kokodo/apigatewayservice/filter/MemberAuthenticationFilter.java
@@ -34,6 +34,7 @@ public class MemberAuthenticationFilter extends AbstractGatewayFilterFactory<Mem
         return ((exchange, chain) -> {
             ServerHttpRequest req = exchange.getRequest();
 
+            // TODO: Header AUTHORIZATION Null 처리
             String header = req.getHeaders().get(HttpHeaders.AUTHORIZATION).get(0);
             String accessToken = (header != null && header.startsWith(TOKEN_PREFIX)) ? header.replace(TOKEN_PREFIX,"") : null;
 

--- a/src/main/java/shop/kokodo/apigatewayservice/filter/MemberAuthenticationFilter.java
+++ b/src/main/java/shop/kokodo/apigatewayservice/filter/MemberAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package shop.kokodo.apigatewayservice.filter;
+
+import io.jsonwebtoken.JwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import shop.kokodo.apigatewayservice.utils.JwtTokenUtil;
+
+@Slf4j
+@Component
+public class MemberAuthenticationFilter extends AbstractGatewayFilterFactory<MemberAuthenticationFilter.Config> {
+
+    private final JwtTokenUtil jwtTokenUtil;
+
+    String TOKEN_PREFIX = "Bearer ";
+
+    @Value("${token.member.secret}")
+    private String secret;
+
+    public MemberAuthenticationFilter(JwtTokenUtil jwtTokenUtil) {
+        super(Config.class);
+        this.jwtTokenUtil = jwtTokenUtil;
+    }
+
+    public static class Config {}
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            ServerHttpRequest req = exchange.getRequest();
+
+            String header = req.getHeaders().get(HttpHeaders.AUTHORIZATION).get(0);
+            String accessToken = (header != null && header.startsWith(TOKEN_PREFIX)) ? header.replace(TOKEN_PREFIX,"") : null;
+
+            // Request Header 에 Access Token (Authorization) 이 담긴 경우
+            if (!ObjectUtils.isEmpty(accessToken)) {
+                // Access Token 이 만료된 경우
+                if(jwtTokenUtil.isTokenExpired(accessToken, secret)) {
+                    throw new JwtException("토큰 만료");
+                }
+
+                if (jwtTokenUtil.isInvalidToken(accessToken, secret)) {
+                    throw new JwtException("유효하지 않은 토큰");
+                }
+            }
+
+            log.debug("JWT 유효성 검사 완료");
+            return chain.filter(exchange);
+        });
+    }
+}

--- a/src/main/java/shop/kokodo/apigatewayservice/filter/SellerAuthenticationFilter.java
+++ b/src/main/java/shop/kokodo/apigatewayservice/filter/SellerAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package shop.kokodo.apigatewayservice.filter;
+
+import io.jsonwebtoken.JwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import shop.kokodo.apigatewayservice.utils.JwtTokenUtil;
+
+@Slf4j
+@Component
+public class SellerAuthenticationFilter extends AbstractGatewayFilterFactory<SellerAuthenticationFilter.Config> {
+
+    private final JwtTokenUtil jwtTokenUtil;
+
+    String TOKEN_PREFIX = "Bearer ";
+
+    @Value("${token.seller.secret}")
+    private String secret;
+
+    public SellerAuthenticationFilter(JwtTokenUtil jwtTokenUtil) {
+        super(Config.class);
+        this.jwtTokenUtil = jwtTokenUtil;
+    }
+
+    public static class Config {}
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            ServerHttpRequest req = exchange.getRequest();
+
+            String header = req.getHeaders().get(HttpHeaders.AUTHORIZATION).get(0);
+            String accessToken = (header != null && header.startsWith(TOKEN_PREFIX)) ? header.replace(TOKEN_PREFIX,"") : null;
+
+            // Request Header 에 Access Token (Authorization) 이 담긴 경우
+            if (!ObjectUtils.isEmpty(accessToken)) {
+                // Access Token 이 만료된 경우
+                if(jwtTokenUtil.isTokenExpired(accessToken, secret)) {
+                    throw new JwtException("토큰 만료");
+                }
+
+                if (jwtTokenUtil.isInvalidToken(accessToken, secret)) {
+                    throw new JwtException("유효하지 않은 토큰");
+                }
+            }
+
+            log.debug("JWT 유효성 검사 완료");
+            return chain.filter(exchange);
+        });
+    }
+}

--- a/src/main/java/shop/kokodo/apigatewayservice/utils/JwtTokenUtil.java
+++ b/src/main/java/shop/kokodo/apigatewayservice/utils/JwtTokenUtil.java
@@ -1,0 +1,61 @@
+package shop.kokodo.apigatewayservice.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class JwtTokenUtil implements Serializable {
+
+    private static final Long serialVersionUID = -2550185165626007488L;
+
+    public Boolean isTokenExpired(String token, String secret) {
+        final Date expiration = getExpirationDateFromToken(token, secret);
+        return expiration.before(new Date());
+    }
+
+    public Date getExpirationDateFromToken(String token, String secret) {
+        return getClaimFromToken(token, secret, Claims::getExpiration);
+    }
+
+    public Boolean isInvalidToken(String token, String secret) {
+        try {
+            getAllClaimsFromToken(token, secret);
+        } catch (IllegalArgumentException | SignatureException e) {
+            e.printStackTrace();
+            return true;
+        }
+        return false;
+    }
+
+    public <T> T getClaimFromToken(String token, String secret, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaimsFromToken(token, secret);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims getAllClaimsFromToken(String token, String secret) {
+        try {
+            return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+        }
+        catch (ExpiredJwtException e) {
+            log.error("JWT 토큰 만료.");
+            throw e;
+        }
+        catch (SignatureException e) {
+            log.error("JWT 토큰 서명 검증 실패. 암복호화 secret 불일치.");
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/member-service/(?<segment>.*), /$\{segment}
-             - MemberAuthenticationFilter
+            - MemberAuthenticationFilter
 
         # 주문 서비스
         - id: order-service
@@ -100,7 +100,7 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/promotion-service/(?<segment>.*), /$\{segment}
-           - MemberAuthenticationFilter
+            - MemberAuthenticationFilter
 
         # 정산 서비스
         - id: calculate-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,13 +13,6 @@ eureka:
 spring:
   application:
     name: apigateway-service
-  # RabbitMQ 등록
-  rabbitmq:
-    host: 127.0.0.1
-    #RabbitMq가 접근할 때 사용하는 port
-    port: 5672
-    username: guest
-    password: guest
   cloud:
     gateway:
       # CORS 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,163 @@
+server:
+  port: 8001
+
+eureka:
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:9001/eureka
+
+spring:
+  application:
+    name: apigateway-service
+  # RabbitMQ 등록
+  rabbitmq:
+    host: 127.0.0.1
+    #RabbitMq가 접근할 때 사용하는 port
+    port: 5672
+    username: guest
+    password: guest
+  cloud:
+    gateway:
+      # CORS 설정
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOrigins: 'http://localhost:9090'
+            #            allow-credentials: true
+            allowedHeaders: '*'
+            allowedMethods: '*'
+        add-to-simple-url-handler-mapping: true
+      routes:
+
+        # 로그인 API
+        - id: member-service
+          uri: lb://MEMBER-SERVICE
+          predicates:
+            - Path=/member-service/login
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/member-service/(?<segment>.*), /$\{segment}
+
+        # OAuth (Naver, Kakao)
+        - id: member-service
+          uri: lb://MEMBER-SERVICE
+          predicates:
+            - Path=/member-service/oauth/**
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/member-service/(?<segment>.*), /$\{segment}
+
+        # 회원가입 API
+        - id: member-service
+          uri: lb://MEMBER-SERVICE
+          predicates:
+            - Path=/member-service/member/signup/**
+            - Method=POST, GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/member-service/(?<segment>.*), /$\{segment}
+
+        # 회원 API
+        # 로그인과 회원가입을 제외한 회원 서비스로의 API 는 모두 권한 인증 처리
+        - id: member-service
+          uri: lb://MEMBER-SERVICE
+          predicates:
+            - Path=/member-service/**
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/member-service/(?<segment>.*), /$\{segment}
+             - MemberAuthenticationFilter
+
+        # 주문 서비스
+        - id: order-service
+          uri: lb://ORDER-SERVICE
+          predicates:
+            - Path=/order-service/**
+            - Method=GET,POST,PATCH
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/order-service/(?<segment>.*), /$\{segment}
+            - MemberAuthenticationFilter
+
+        # 상품 서비스 (사용자 기능)
+        - id: product-service
+          uri: lb://PRODUCT-SERVICE
+          predicates:
+            - Path=/product-service/**
+            - Method=GET,POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/product-service/(?<segment>.*), /$\{segment}
+
+        # 프로모션 서비스 (사용자 기능)
+        - id: promotion-service
+          uri: lb://PROMOTION-SERVICE
+          predicates:
+            - Path=/promotion-service/**
+            - Method=GET,POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/promotion-service/(?<segment>.*), /$\{segment}
+           - MemberAuthenticationFilter
+
+        # 정산 서비스
+        - id: calculate-service
+          uri: lb://CALCULATE-SERVICE
+          predicates:
+            - Path=/calculate-service/**
+            - Method=GET,POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/calculate-service/(?<segment>.*), /$\{segment}
+        #   - SellerAuthenticationFilter
+
+        # 셀러 서비스
+        - id: seller-service
+          uri: lb://SELLER-SERVICE
+          predicates:
+            - Path=/seller-service/login
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/seller-service/(?<segment>.*), /$\{segment}
+
+        - id: seller-service
+          uri: lb://SELLER-SERVICE
+          predicates:
+            - Path=/seller-service/seller/signup
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/seller-service/(?<segment>.*), /$\{segment}
+
+        - id: seller-service
+          uri: lb://SELLER-SERVICE
+          predicates:
+            - Path=/seller-service/**
+            - Method=GET,POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/seller-service/(?<segment>.*), /$\{segment}
+            - SellerAuthenticationFilter
+
+token:
+  member:
+    secret: member_token
+  seller:
+    secret: seller_token
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh, health, beans, httptrace, busrefresh, info, prometheus, metrics

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
           uri: lb://MEMBER-SERVICE
           predicates:
             - Path=/member-service/oauth/**
-            - Method=POST
+            - Method=GET
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/member-service/(?<segment>.*), /$\{segment}
@@ -52,7 +52,7 @@ spring:
         - id: member-service
           uri: lb://MEMBER-SERVICE
           predicates:
-            - Path=/member-service/member/signup/**
+            - Path=/member-service/member/signup
             - Method=POST, GET
           filters:
             - RemoveRequestHeader=Cookie


### PR DESCRIPTION
# 설명
* 판매자와 클라이언트 서비스에 대한 필터를 분리했습니다.
* 추후 헤더에 Authorization 필드 Null 체크를 추가할 예정입니다.

```
        # 프로모션 서비스 (사용자 기능)
        - id: promotion-service
          uri: lb://PROMOTION-SERVICE
          predicates:
            - Path=/promotion-service/**
            - Method=GET,POST
          filters:
            - RemoveRequestHeader=Cookie
            - RewritePath=/promotion-service/(?<segment>.*), /$\{segment}
            - MemberAuthenticationFilter 🚨

        # 셀러서비스
        - id: seller-service
          uri: lb://SELLER-SERVICE
          predicates:
            - Path=/seller-service/**
            - Method=GET,POST
          filters:
            - RemoveRequestHeader=Cookie
            - RewritePath=/seller-service/(?<segment>.*), /$\{segment}
            - SellerAuthenticationFilter 🚨
```

* 판매자와 회원의 토큰을 다르게 발급함에 따라 토큰의 secret 값이 2개가 필요합니다. application.yml 에 아래의 내용을 추가했습니다.
```
token:
  member:
    secret: member_token
  seller:
    secret: seller_token
```
